### PR TITLE
Derive Generic instance for URI with GHC >= 7.6

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -139,6 +139,11 @@ import Data.Data (Data)
 import Data.Generics (Data)
 #endif
 
+#if MIN_VERSION_base(4,6,0)
+import GHC.Generics (Generic)
+#else
+#endif
+
 ------------------------------------------------------------
 --  The URI datatype
 ------------------------------------------------------------
@@ -158,7 +163,11 @@ data URI = URI
     , uriPath       :: String           -- ^ @\/ghc@
     , uriQuery      :: String           -- ^ @?query@
     , uriFragment   :: String           -- ^ @#frag@
+#if MIN_VERSION_base(4,6,0)
+    } deriving (Eq, Ord, Typeable, Data, Generic)
+#else
     } deriving (Eq, Ord, Typeable, Data)
+#endif
 
 instance NFData URI where
     rnf (URI s a p q f)

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -39,6 +39,9 @@ library
     deepseq >= 1.1 && < 1.4,
     parsec >= 3.0 && < 3.2
   default-extensions: CPP, DeriveDataTypeable
+ if impl(ghc >= 7.6) {
+  default-extensions: DeriveGeneric
+ }
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell98
 


### PR DESCRIPTION
If GHC >= 7.6 with base >= 4.6 is used, `Generic` is derived from
`URI`. One benefit is the automatic generation of a `Hashable`
instance for `URI`s. See

https://hackage.haskell.org/package/hashable/docs/Data-Hashable.html

I'd be happy to be persuaded that this pull request is either 1) not desirable or 2) malformed.
