### PR TITLE
fix network-uri flag example in cabal file

### DIFF
--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -18,7 +18,7 @@ description:
   >   if flag(network-uri)
   >     build-depends: network-uri >= 2.6, network >= 2.6
   >   else
-  >     build-depends: network-uri < 2.6, network < 2.6
+  >     build-depends: network < 2.6
   .
   That is, get the module from either network < 2.6 or from
   network-uri >= 2.6.


### PR DESCRIPTION
Since network-uri module was created when network 2.6 was released,
expression `network-uri < 2.6` is not necessary, moreover it will always fail.