### PR TITLE
Added ability to get segments of a URI

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -102,7 +102,7 @@ module Network.URI
     , isUnescapedInURIComponent
     , escapeURIChar
     , escapeURIString
-    , segmentsURI
+    , pathSegments
     , unEscapeString
 
     -- * URI Normalization functions
@@ -1095,8 +1095,8 @@ segments = unfoldr nextSegmentMaybe
         nextSegmentMaybe [] = Nothing
         nextSegmentMaybe ps = Just $ nextSegment ps
 
-segmentsURI :: URI -> [String]
-segmentsURI = segments . uriPath
+pathSegments :: URI -> [String]
+pathSegments = segments . uriPath
 
 --  Split last (name) segment from path, returning (path,name)
 splitLast :: String -> (String,String)

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -1092,8 +1092,12 @@ nextSegment ps =
 segments :: String -> [String]
 segments = unfoldr nextSegmentMaybe
     where
-        nextSegmentMaybe [] = Nothing
-        nextSegmentMaybe ps = Just $ nextSegment ps
+        nextSegmentMaybe ('/':ps) = next ps --So that we do not get empty segments
+        nextSegmentMaybe ps = next ps
+        next ps =
+            case break (=='/') ps of
+                (r,'/':ps1) -> Just (r,ps1)
+                (_,_)       -> Nothing
 
 pathSegments :: URI -> [String]
 pathSegments = segments . uriPath

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -102,6 +102,7 @@ module Network.URI
     , isUnescapedInURIComponent
     , escapeURIChar
     , escapeURIString
+    , segmentsURI
     , unEscapeString
 
     -- * URI Normalization functions
@@ -129,6 +130,7 @@ import Control.Monad (MonadPlus(..))
 import Control.DeepSeq (NFData(rnf), deepseq)
 import Data.Char (ord, chr, isHexDigit, toLower, toUpper, digitToInt)
 import Data.Bits ((.|.),(.&.),shiftL,shiftR)
+import Data.List (unfoldr)
 import Numeric (showIntAtBase)
 
 #if !MIN_VERSION_base(4,8,0)
@@ -1086,6 +1088,15 @@ nextSegment ps =
     case break (=='/') ps of
         (r,'/':ps1) -> (r++"/",ps1)
         (r,_)       -> (r,[])
+
+segments :: String -> [String]
+segments = unfoldr nextSegmentMaybe
+    where
+        nextSegmentMaybe [] = Nothing
+        nextSegmentMaybe ps = Just $ nextSegment ps
+
+segmentsURI :: URI -> [String]
+segmentsURI = segments . uriPath
 
 --  Split last (name) segment from path, returning (path,name)
 splitLast :: String -> (String,String)

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -1092,10 +1092,8 @@ nextSegment ps =
 segments :: String -> [String]
 segments = unfoldr nextSegmentMaybe
     where
-        nextSegmentMaybe ('/':ps) = next ps --So that we do not get empty segments
-        nextSegmentMaybe ps = next ps
-        next ps =
-            case break (=='/') ps of
+        nextSegmentMaybe ps =
+            case break (=='/') ({- Get rid of empty segments -} snd $ break (/='/') ps) of
                 (r,'/':ps1) -> Just (r,ps1)
                 (_,_)       -> Nothing
 

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -1097,6 +1097,7 @@ segments = unfoldr nextSegmentMaybe
                 (r,'/':ps1) -> Just (r,ps1)
                 (_,_)       -> Nothing
 
+-- | Splits a 'URI' into its path components.
 pathSegments :: URI -> [String]
 pathSegments = segments . uriPath
 


### PR DESCRIPTION
For example:

```
> segmentsURI <$> parseURI "http://hackage.haskell.org/package/network-uri-2.6.0.3/docs/Network-URI.html"
Just ["/","package/","network-uri-2.6.0.3/","docs/","Network-URI.html"]
```

This is useful for pattern matching in conjunction with a web scraper:

```
case (segmentsURI <$> parseURI url) of
    Just ["/", "package/","network-uri-2.6.0.3/","docs/",docPage] -> Just docPage
    _ -> Nothing
```

For example: I'm doing a project where I scrape urls from `tvtropes.org`, which have a good bit of structure.