### PR TITLE
allow ``[]`` (gen-delims) in uquery parser

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -695,7 +695,7 @@ uchar extras =
 
 uquery :: URIParser String
 uquery =
-    do  { ss <- many $ uchar (":@"++"/?")
+    do  { ss <- many $ uchar (":@[]"++"/?")
         ; return $ '?':concat ss
         }
 


### PR DESCRIPTION
otherwise parseURI return Nothing with below URL:

```
  https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=icaclient
```

Python or chrome web browser both parse above link as valid URI.

Python (3.5):

```
>>> from urllib.parse import urlparse
>>> urlparse('https://aur.archlinux.org/rpc/?v=5&type=info&arg[]=icaclient')
ParseResult(scheme='https', netloc='aur.archlinux.org', path='/rpc/', params='', query='v=5&type=info&arg[]=icaclient', fragment='')
>>> 
```