### PR TITLE
Add lenses for network uri

### DIFF
--- a/Network/URI/Lens.hs
+++ b/Network/URI/Lens.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE Rank2Types #-}
+-- | Network uri lenses
+module Network.URI.Lens
+  ( regNameLens
+  , userInfoLens
+  , portLens
+  , uriAuthLens
+  , uriSchemeLens
+  , uriPathLens
+  , uriQueryLens
+  , uriFragmentLens
+  ) where
+
+import           Network.URI
+
+type Lens' s a = Lens s s a a
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+
+lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
+lens sa sbt afb s = sbt s <$> afb (sa s)
+
+regNameLens :: Lens' URIAuth String
+regNameLens = lens uriRegName (\parent newVal -> parent {uriRegName = newVal})
+
+userInfoLens :: Lens' URIAuth String
+userInfoLens =
+  lens uriUserInfo (\parent newVal -> parent {uriUserInfo = newVal})
+
+portLens :: Lens' URIAuth String
+portLens = lens uriPort (\parent newVal -> parent {uriPort = newVal})
+
+uriAuthLens :: Lens' URI (Maybe URIAuth)
+uriAuthLens =
+  lens uriAuthority (\parent newVal -> parent {uriAuthority = newVal})
+
+uriSchemeLens :: Lens' URI String
+uriSchemeLens = lens uriScheme (\parent newVal -> parent {uriScheme = newVal})
+
+uriPathLens :: Lens' URI String
+uriPathLens = lens uriPath (\parent newVal -> parent {uriPath = newVal})
+
+uriQueryLens :: Lens' URI String
+uriQueryLens = lens uriQuery (\parent newVal -> parent {uriQuery = newVal})
+
+uriFragmentLens :: Lens' URI String
+uriFragmentLens =
+  lens uriFragment (\parent newVal -> parent {uriFragment = newVal})

--- a/Network/URI/Lens.hs
+++ b/Network/URI/Lens.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE Rank2Types #-}
 -- | Network uri lenses
 module Network.URI.Lens
-  ( regNameLens
-  , userInfoLens
-  , portLens
-  , uriAuthLens
+  ( uriRegNameLens
+  , uriUserInfoLens
+  , uriPortLens
+  , uriAuthorityLens
   , uriSchemeLens
   , uriPathLens
   , uriQueryLens
@@ -19,18 +19,18 @@ type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
 lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
 lens sa sbt afb s = sbt s <$> afb (sa s)
 
-regNameLens :: Lens' URIAuth String
-regNameLens = lens uriRegName (\parent newVal -> parent {uriRegName = newVal})
+uriRegNameLens :: Lens' URIAuth String
+uriRegNameLens = lens uriRegName (\parent newVal -> parent {uriRegName = newVal})
 
-userInfoLens :: Lens' URIAuth String
-userInfoLens =
+uriUserInfoLens :: Lens' URIAuth String
+uriUserInfoLens =
   lens uriUserInfo (\parent newVal -> parent {uriUserInfo = newVal})
 
-portLens :: Lens' URIAuth String
-portLens = lens uriPort (\parent newVal -> parent {uriPort = newVal})
+uriPortLens :: Lens' URIAuth String
+uriPortLens = lens uriPort (\parent newVal -> parent {uriPort = newVal})
 
-uriAuthLens :: Lens' URI (Maybe URIAuth)
-uriAuthLens =
+uriAuthorityLens :: Lens' URI (Maybe URIAuth)
+uriAuthorityLens =
   lens uriAuthority (\parent newVal -> parent {uriAuthority = newVal})
 
 uriSchemeLens :: Lens' URI String

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -49,6 +49,7 @@ tested-with: GHC==8.2.1, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7
 library
   exposed-modules:
     Network.URI
+    Network.URI.Lens
   build-depends:
     base >= 3 && < 5,
     deepseq >= 1.1 && < 1.5,


### PR DESCRIPTION
This makes working with network uri simpler.

Once this is merged I can deprecate: http://hackage.haskell.org/package/network-uri-lenses