### PR TITLE
Mark SafeHaskell explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# network-uri-2.6.3.0 (TBD)
+* Add official support for SafeHaskell
+  NOTE: This is the first version whose SafeHaskell properties have become an intentional part of the API contract; previous versions were merely accidentally safe-inferred (or not depending on various factors; in other words, this was a fragile property).
+* Derive `Lift` instances using `DeriveLift` extension, when available.
+
 # network-uri-2.6.2.0 (2020-01-30)
 * Merge network-uri-static (Network.URI.Static) into this package
 * Add `Lens`es for the `URI` types

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -1,9 +1,15 @@
 {-# LANGUAGE RecordWildCards, CPP #-}
-#if __GLASGOW_HASKELL__ < 800
-{-# LANGUAGE TemplateHaskell #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE DeriveLift, StandaloneDeriving #-}
 #else
-{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 #endif
+#if MIN_VERSION_template_haskell(2,12,0) && MIN_VERSION_parsec(3,13,0)
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
 --------------------------------------------------------------------------------
 -- |
 --  Module      :  Network.URI
@@ -1370,11 +1376,16 @@ normalizePathSegments uristr = normstr juri
 --  Lift instances to support Network.URI.Static
 ------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ >= 800
+deriving instance Lift URI
+deriving instance Lift URIAuth
+#else
 instance Lift URI where
     lift (URI {..}) = [| URI {..} |]
 
 instance Lift URIAuth where
     lift (URIAuth {..}) = [| URIAuth {..} |]
+#endif
 
 ------------------------------------------------------------
 --  Deprecated functions

--- a/Network/URI/Lens.hs
+++ b/Network/URI/Lens.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
+#if __GLASGOW_HASKELL__ > 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ > 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 -- | Network uri lenses
 module Network.URI.Lens
   ( uriRegNameLens

--- a/Network/URI/Static.hs
+++ b/Network/URI/Static.hs
@@ -3,6 +3,11 @@
 #else
 {-# LANGUAGE RecordWildCards, TemplateHaskellQuotes, ViewPatterns #-}
 #endif
+#if MIN_VERSION_template_haskell(2,12,0)
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
 module Network.URI.Static
     (
     -- * Absolute URIs

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -1,5 +1,5 @@
 name:                network-uri
-version:             2.6.2.0
+version:             2.6.3.0
 synopsis:            URI manipulation
 description:
   This package provides facilities for parsing and unparsing URIs, and creating
@@ -67,7 +67,7 @@ library
   build-depends:
     base >= 3 && < 5,
     deepseq >= 1.1 && < 1.5,
-    parsec >= 3.0 && < 3.2
+    parsec >= 3.1.12.0 && < 3.2
   build-depends: template-haskell
   default-extensions: CPP, DeriveDataTypeable
   if impl(ghc < 7.6)


### PR DESCRIPTION
This fixes a transient failure in compiling e.g. `http-link-header`
which relied on `network-uri` to be Safe/Trustworthy.

Also use `DeriveLift`, this fixes e.g. a clear error (though only
warning from GHC point-of-view), when GHC-8.10 is used:

    Network/URI.hs:1381:10: warning: [-Wmissing-methods]
        • No explicit implementation for
            ‘liftTyped’
        • In the instance declaration for ‘Lift URI’
         |
    1381 | instance Lift URI where
         |

There's an issue with GHC-8.10 release candidate, which I hope to fix for release proper: https://gitlab.haskell.org/ghc/ghc/issues/17813