### PR TITLE
Fixed unused import for newer GHC versions

### DIFF
--- a/Network/URI/Lens.hs
+++ b/Network/URI/Lens.hs
@@ -17,7 +17,9 @@ module Network.URI.Lens
   , uriFragmentLens
   ) where
 
+#if __GLASGOW_HASKELL__ < 701
 import           Control.Applicative
+#endif
 import           Network.URI
 
 type Lens' s a = Lens s s a a


### PR DESCRIPTION
Got this warning during compiling

```
network-uri                > [2 of 3] Compiling Network.URI.Lens    
network-uri                >                                        
network-uri                > /tmp/stack22672/network-uri-2.6.2.0/Network/URI/Lens.hs:14:1: warning: [-Wunused-imports]
network-uri                >     The import of ‘Control.Applicative’ is redundant
network-uri                >       except perhaps to import instances from ‘Control.Applicative’
network-uri                >     To import instances alone, use: import Control.Applicative()
network-uri                >    |                                   
network-uri                > 14 | import           Control.Applicative
network-uri                >    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
network-uri                > [3 of 3] Compiling Network.URI.Static  
```

Pretty sure this import is not needed all the way back to GHC 7.10

Was not entirely sure whether to keep compatibility with even older GHC versions so made a pragma instead of deleting this line