### PR TITLE
mark as safe for GHC >=8.8

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -6,6 +6,8 @@
 #endif
 #if MIN_VERSION_template_haskell(2,12,0) && MIN_VERSION_parsec(3,13,0)
 {-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 808
+{-# LANGUAGE Safe #-}
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif


### PR DESCRIPTION
For GHC >=8.8, the package _is_ `Safe`, so we can mark it as safe.