### PR TITLE
Expose the main Parsec combinators from the library

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -125,6 +125,9 @@ module Network.URI
     , normalizeEscape
     , normalizePathSegments
 
+    -- * Raw Parsec parsers
+    , uriParser, relativeReferenceParser
+
     -- * Deprecated functions
     , parseabsoluteURI
     , escapeString
@@ -468,6 +471,11 @@ unreservedChar = (:[]) <$> satisfy isUnreserved
 --               / path-abs
 --               / path-rootless
 --               / path-empty
+
+-- | A Parsec parser for any complete URI, or what is often called an "absolute" URI,
+-- that is one that begins with a scheme like "http://".
+uriParser :: URIParser URI
+uriParser = uri  -- Note the name is for module export
 
 uri :: URIParser URI
 uri =
@@ -818,6 +826,12 @@ uriReference = uri <|> relativeRef
 --                 / path-abs
 --                 / path-noscheme
 --                 / path-empty
+
+-- | A Parsec parser for a "relative URI reference", that is a string that can
+-- be interpreted as a URI relative to some absolute base URI. A common
+-- example would be a simple path, such as "/poets/persian/rumi".
+relativeReferenceParser :: URIParser URI
+relativeReferenceParser = relativeRef  -- Note the name is for module export
 
 relativeRef :: URIParser URI
 relativeRef =

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -86,9 +86,9 @@ test-suite uri
     base < 5,
     HUnit,
     network-uri,
-    test-framework,
-    test-framework-hunit,
-    test-framework-quickcheck2,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
     QuickCheck
 
   ghc-options: -Wall -fwarn-tabs

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -104,7 +104,8 @@ benchmark uri-bench
     HUnit,
     network-uri,
     criterion,
-    deepseq
+    deepseq,
+    random
 
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell98

--- a/tests/uri001.hs
+++ b/tests/uri001.hs
@@ -59,9 +59,9 @@ import Data.Char (ord, chr)
 import Data.Maybe (fromJust)
 import Data.List (intercalate)
 import System.IO (openFile, IOMode(WriteMode), hClose)
-import qualified Test.Framework as TF
-import qualified Test.Framework.Providers.HUnit as TF
-import qualified Test.Framework.Providers.QuickCheck2 as TF
+import qualified Test.Tasty as TF
+import qualified Test.Tasty.QuickCheck as TF
+import qualified Test.Tasty.HUnit as TF
 import Test.QuickCheck ((==>), Property)
 
 -- Test supplied string for valid URI reference syntax
@@ -1353,7 +1353,7 @@ testRectify = TF.testGroup "testRectify"
   ]
 
 -- Full test suite
-allTests =
+allTests = TF.testGroup "all"
   [ testURIRefSuite
   , testComponentSuite
   , testRelativeSuite


### PR DESCRIPTION
Following https://github.com/haskell/network-uri/issues/56, this is a proposal to expose a couple of main Parsec parsers so that users can compose further combinators on top of them.

My inclination is to be conservative and start small in terms of which parsers we expose.

Note also I exposed the existing parsers under new names, so that
  (a) they match the corresponding `parseX` functions, and
  (b) they have `...Parser` in their names so they're easily identified as Parsec items.