### PR TITLE
Remark Network.URI.Static as Safe using th-compat-0.1.1

### DIFF
--- a/Network/URI/Static.hs
+++ b/Network/URI/Static.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards, TemplateHaskellQuotes, ViewPatterns #-}
 #endif
 #if MIN_VERSION_template_haskell(2,12,0)
--- {-# LANGUAGE Safe #-}
+{-# LANGUAGE Safe #-}
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -69,7 +69,7 @@ library
     base >= 3 && < 5,
     deepseq >= 1.1 && < 1.5,
     parsec >= 3.1.12.0 && < 3.2,
-    th-compat >= 0.1 && < 1.0
+    th-compat >= 0.1.1 && < 1.0
   build-depends: template-haskell
   default-extensions: CPP, DeriveDataTypeable
   if impl(ghc < 7.6)


### PR DESCRIPTION
I noticed that 4f8c4ffce8e16eff7a09adfbbbacc5bee29b585f uncommented the use of `{-# LANGUAGE Safe #-}` in `Network.URI.Static`. I think this is (unintentionally) my fault, as I forgot to mark `Language.Haskell.TH.Syntax.Compat` as `Trustworthy` in the initial release of `th-compat-0.1`, and as a result, `Language.Haskell.TH.Syntax.Compat` was inferred to be `Unsafe` due to the fact that it imports from `GHC.Exts`. I have since released `th-compat-0.1.1` which marks that module as `Trustworthy`, which allows `Network.URI.Static` to be marked as `Safe`.