### PR TITLE
Add safe haskell warnings

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -4,7 +4,7 @@
 #else
 {-# LANGUAGE TemplateHaskell #-}
 #endif
-#if MIN_VERSION_template_haskell(2,12,0) && MIN_VERSION_parsec(3,13,0)
+#if MIN_VERSION_template_haskell(2,12,0) && MIN_VERSION_parsec(3,1,13)
 {-# LANGUAGE Safe #-}
 #elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}

--- a/network-uri.cabal
+++ b/network-uri.cabal
@@ -79,6 +79,11 @@ library
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell98
 
+  if impl(ghc >= 9.0)
+    -- these flags may abort compilation with GHC-8.10
+    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
+    ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
+
 test-suite uri
   hs-source-dirs: tests
   main-is: uri001.hs


### PR DESCRIPTION
So https://github.com/haskell/network-uri/pull/60 wont repeat.
Also it seems I made a mistake in CPP for parsec,
luckily in a overconservative manner, so it was just annoying