### PR TITLE
Add Read instance to URI data type

### DIFF
--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -197,7 +197,7 @@ data URI = URI
 instance Read URI where
          readsPrec _ v 
             | isJust mUri = return (fromJust mUri, "")
-            | otherwise = return (URI "" Nothing "" "" "", "")
+            | otherwise = [] 
             where
                 mUri = parseURI v
 

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -194,13 +194,6 @@ data URI = URI
     } deriving (Eq, Ord, Typeable, Data)
 #endif
 
-instance Read URI where
-         readsPrec _ v 
-            | isJust mUri = return (fromJust mUri, "")
-            | otherwise = [] 
-            where
-                mUri = parseURI v
-
 -- | Add a prefix to a string, unless it already has it.
 ensurePrefix :: String -> String -> String
 ensurePrefix p s = if p `isPrefixOf` s then s else p ++ s
@@ -238,6 +231,13 @@ unlessEmpty  f  x = f x
 instance NFData URI where
     rnf (URI s a p q f)
         = s `deepseq` a `deepseq` p `deepseq` q `deepseq` f `deepseq` ()
+
+instance Read URI where
+         readsPrec _ v 
+            | isJust mUri = return (fromJust mUri, "")
+            | otherwise = [] 
+            where
+                mUri = parseURI v
 
 -- |Type for authority value within a URI
 data URIAuth = URIAuth

--- a/Network/URI.hs
+++ b/Network/URI.hs
@@ -149,6 +149,7 @@ import Control.DeepSeq (NFData(rnf), deepseq)
 import Data.Char (ord, chr, isHexDigit, toLower, toUpper, digitToInt)
 import Data.Bits ((.|.),(.&.),shiftL,shiftR)
 import Data.List (unfoldr, isPrefixOf, isSuffixOf)
+import Data.Maybe (fromJust, isJust)
 import Numeric (showIntAtBase)
 
 import Language.Haskell.TH.Syntax (Lift(..))
@@ -192,6 +193,13 @@ data URI = URI
 #else
     } deriving (Eq, Ord, Typeable, Data)
 #endif
+
+instance Read URI where
+         readsPrec _ v 
+            | isJust mUri = return (fromJust mUri, "")
+            | otherwise = return (URI "" Nothing "" "" "", "")
+            where
+                mUri = parseURI v
 
 -- | Add a prefix to a string, unless it already has it.
 ensurePrefix :: String -> String -> String

--- a/tests/uri001.hs
+++ b/tests/uri001.hs
@@ -1225,10 +1225,6 @@ testAltFn15 = testEq "testAltFn15" True  (isAbsoluteURI "http://a.b/c")
 testAltFn16 = testEq "testAltFn16" False (isAbsoluteURI "http://a.b/c#f")
 testAltFn17 = testEq "testAltFn17" False (isAbsoluteURI "c/d")
 
-testReadUri = testEq "testReadUri" True (isJust (readMaybe "http://a.b" :: Maybe URI))
-testReadBadUri = testEq "testReadBadUri" True (isNothing (readMaybe "baduri" :: Maybe URI))
-testReadRoundtrip = testEq "testReadRoundtrip" "http://a.b" (show (read "http://a.b" :: URI))
-
 testAltFn = TF.testGroup "testAltFn"
   [ TF.testCase "testAltFn01" testAltFn01
   , TF.testCase "testAltFn02" testAltFn02
@@ -1337,6 +1333,10 @@ testRectify = TF.testGroup "testRectify"
     "//ezra@www.google.com:80"
     ((uriAuthToString id . Just . rectifyAuth $ URIAuth "ezra" "www.google.com" "80") "")
   ]
+
+testReadUri = testEq "testReadUri" True (isJust (readMaybe "http://a.b" :: Maybe URI))
+testReadBadUri = testEq "testReadBadUri" True (isNothing (readMaybe "baduri" :: Maybe URI))
+testReadRoundtrip = testEq "testReadRoundtrip" "http://a.b" (show (read "http://a.b" :: URI))
 
 testRead = TF.testGroup "testRead" [
   TF.testCase "testReadUri" testReadUri

--- a/tests/uri001.hs
+++ b/tests/uri001.hs
@@ -48,13 +48,14 @@ import Test.HUnit
 
 import Data.Bits ((.&.), (.|.))
 import Data.Char (ord, chr)
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, isJust, isNothing)
 import Data.List (intercalate)
 import System.IO (openFile, IOMode(WriteMode), hClose)
 import qualified Test.Tasty as TF
 import qualified Test.Tasty.HUnit as TF
 import qualified Test.Tasty.QuickCheck as TF
 import Test.QuickCheck ((==>), Property)
+import Text.Read (readMaybe)
 
 data URIType = AbsId    -- URI form (absolute, no fragment)
              | AbsRf    -- Absolute URI reference
@@ -1224,6 +1225,10 @@ testAltFn15 = testEq "testAltFn15" True  (isAbsoluteURI "http://a.b/c")
 testAltFn16 = testEq "testAltFn16" False (isAbsoluteURI "http://a.b/c#f")
 testAltFn17 = testEq "testAltFn17" False (isAbsoluteURI "c/d")
 
+testReadUri = testEq "testReadUri" True (isJust (readMaybe "http://a.b" :: Maybe URI))
+testReadBadUri = testEq "testReadBadUri" True (isNothing (readMaybe "baduri" :: Maybe URI))
+testReadRoundtrip = testEq "testReadRoundtrip" "http://a.b" (show (read "http://a.b" :: URI))
+
 testAltFn = TF.testGroup "testAltFn"
   [ TF.testCase "testAltFn01" testAltFn01
   , TF.testCase "testAltFn02" testAltFn02
@@ -1333,6 +1338,12 @@ testRectify = TF.testGroup "testRectify"
     ((uriAuthToString id . Just . rectifyAuth $ URIAuth "ezra" "www.google.com" "80") "")
   ]
 
+testRead = TF.testGroup "testRead" [
+  TF.testCase "testReadUri" testReadUri
+  , TF.testCase "testReadRoundtrip" testReadRoundtrip
+  , TF.testCase "testReadBadUri" testReadBadUri
+  ]
+
 -- Full test suite
 allTests = TF.testGroup "all"
   [ testURIRefSuite
@@ -1350,6 +1361,7 @@ allTests = TF.testGroup "all"
   , testIsRelative
   , testPathSegments
   , testRectify
+  , testRead
   ]
 
 main = TF.defaultMain allTests


### PR DESCRIPTION
I am trying to add the URI instance to aeson like was mentioned [aeson's #842](https://github.com/haskell/aeson/issues/842), but the `URI` data type needs a read instance. It would be messier to create a `newtype` from the URI in the aeson repo so I'm just making a PR here so that it will be cleaner for the PR in aeson. 